### PR TITLE
docs: remove external recommender env access docs

### DIFF
--- a/src/docs/concepts/recommenders/external.md
+++ b/src/docs/concepts/recommenders/external.md
@@ -13,22 +13,7 @@ An external recommender has two fields:
 - `name` is used to uniquely identify an external recommender.
 - `script` is used to access the external HTTP endpoint and convert the result into an array of item IDs. Item IDs that do not exist in the recommender system will be ignored.
 
-Gorse integrates QuickJS to execute the JavaScript. The ability to access environment variables and send HTTP requests has been added. Contributions to add more capabilities are welcome.
-
-### Accessing Environment Variables
-
-In the JavaScript script, you can access environment variables using `env.VARIABLE_NAME`. For instance, to access an environment variable named `API_KEY`, you can use the following code:
-
-```javascript
-const apiKey = env.API_KEY;
-```
-
-::: note
-
-- All environment variables are of the string type.
-- If an environment variable does not exist, accessing it will return `undefined`.
-
-:::
+Gorse integrates QuickJS to execute the JavaScript. The ability to send HTTP requests has been added. Contributions to add more capabilities are welcome.
 
 ### Fetch API
 

--- a/src/zh/docs/concepts/recommenders/external.md
+++ b/src/zh/docs/concepts/recommenders/external.md
@@ -13,22 +13,7 @@ shortTitle: 外部 API
 - `name` 用于唯一标识外部推荐算法。
 - `script` 用于访问外部 HTTP 端点并将结果转换为物品 ID 数组。推荐系统中不存在的物品 ID 将被忽略。
 
-Gorse 集成了 QuickJS 来执行 JavaScript。已添加访问环境变量和发送 HTTP 请求的功能。欢迎贡献以添加更多功能。
-
-### 访问环境变量
-
-在 JavaScript 脚本中，您可以使用 `env.VARIABLE_NAME` 访问环境变量。例如，要访问名为 `API_KEY` 的环境变量，可以使用以下代码：
-
-```javascript
-const apiKey = env.API_KEY;
-```
-
-::: note
-
-- 所有环境变量都是字符串类型。
-- 如果环境变量不存在，访问它将返回 `undefined`。
-
-:::
+Gorse 集成了 QuickJS 来执行 JavaScript。已添加发送 HTTP 请求的功能。欢迎贡献以添加更多功能。
 
 ### Fetch API
 


### PR DESCRIPTION
## Summary

- Remove documentation that says external recommender scripts can access environment variables through `env.VARIABLE_NAME`
- Update both English and Chinese external recommender docs to only mention HTTP request support

## Why

This aligns the docs with gorse-io/gorse@717caed89baffee8d083da2d4ee2e48d537d3df1, which removed the `env` object from external script execution to prevent environment variable exposure.

## Verification

- Searched docs for obsolete `env.VARIABLE_NAME` / environment-variable access references
- `git diff --check`
- `pnpm docs:build`