### PR TITLE
docs: add Hugging Face navbar link

### DIFF
--- a/src/.vuepress/client.ts
+++ b/src/.vuepress/client.ts
@@ -2,6 +2,7 @@ import { defineClientConfig } from "vuepress/client";
 
 import DiscordLink from "./components/DiscordLink.js";
 import GitHubLink from "./components/GitHubLink.js";
+import HuggingFaceLink from "./components/HuggingFaceLink.js";
 import QQLink from "./components/QQLink.js";
 import TwitterLink from "./components/TwitterLink.js";
 import WeChatLink from "./components/WeChatLink.js";
@@ -10,6 +11,7 @@ export default defineClientConfig({
   enhance: ({ app }) => {
     app.component("DiscordLink", DiscordLink);
     app.component("GitHubLink", GitHubLink);
+    app.component("HuggingFaceLink", HuggingFaceLink);
     app.component("QQLink", QQLink);
     app.component("TwitterLink", TwitterLink);
     app.component("WeChatLink", WeChatLink);

--- a/src/.vuepress/components/HuggingFaceLink.ts
+++ b/src/.vuepress/components/HuggingFaceLink.ts
@@ -1,0 +1,19 @@
+import { type FunctionalComponent, h } from "vue";
+
+const HuggingFaceLink: FunctionalComponent = () =>
+  h(
+    "div",
+    { class: "vp-nav-item vp-action" },
+    h("a", {
+      class: "vp-action-link",
+      href: "https://huggingface.co/gorse-io",
+      target: "_blank",
+      rel: "noopener noreferrer",
+      "aria-label": "huggingface",
+      innerHTML: '<i class="iconfont icon-line-huggingface"></i>',
+    })
+  );
+
+HuggingFaceLink.displayName = "HuggingFaceLink";
+
+export default HuggingFaceLink;

--- a/src/.vuepress/theme.ts
+++ b/src/.vuepress/theme.ts
@@ -25,7 +25,7 @@ export default hopeTheme({
       navbarLayout: {
         start: ["Brand"],
         center: ["Links"],
-        end: ["Language", "GitHubLink", "TwitterLink", "DiscordLink", "Outlook", "Search"],
+        end: ["Language", "HuggingFaceLink", "GitHubLink", "TwitterLink", "DiscordLink", "Outlook", "Search"],
       },
 
       // sidebar
@@ -50,7 +50,7 @@ export default hopeTheme({
       navbarLayout: {
         start: ["Brand"],
         center: ["Links"],
-        end: ["Language", "GitHubLink", "WeChatLink", "QQLink", "Outlook", "Search"],
+        end: ["Language", "HuggingFaceLink", "GitHubLink", "WeChatLink", "QQLink", "Outlook", "Search"],
       },
 
       // sidebar
@@ -153,7 +153,7 @@ export default hopeTheme({
     },
 
     icon: {
-      assets: "https://at.alicdn.com/t/c/font_3748819_2tew92pp94w.css",
+      assets: "https://at.alicdn.com/t/c/font_3748819_38n6x0qbyn.css",
     },
 
     // Install @vuepress/plugin-pwa and uncomment these if you want a PWA

--- a/src/.vuepress/theme.ts
+++ b/src/.vuepress/theme.ts
@@ -25,7 +25,7 @@ export default hopeTheme({
       navbarLayout: {
         start: ["Brand"],
         center: ["Links"],
-        end: ["Language", "HuggingFaceLink", "GitHubLink", "TwitterLink", "DiscordLink", "Outlook", "Search"],
+        end: ["Language", "GitHubLink", "HuggingFaceLink", "TwitterLink", "DiscordLink", "Outlook", "Search"],
       },
 
       // sidebar
@@ -50,7 +50,7 @@ export default hopeTheme({
       navbarLayout: {
         start: ["Brand"],
         center: ["Links"],
-        end: ["Language", "HuggingFaceLink", "GitHubLink", "WeChatLink", "QQLink", "Outlook", "Search"],
+        end: ["Language", "GitHubLink", "HuggingFaceLink", "WeChatLink", "QQLink", "Outlook", "Search"],
       },
 
       // sidebar


### PR DESCRIPTION
## Summary

- Add a Hugging Face navbar action linking to https://huggingface.co/gorse-io
- Place it before GitHub/Twitter icons in the English navbar and before GitHub in the Chinese navbar
- Update iconfont asset URL to //at.alicdn.com/t/c/font_3748819_38n6x0qbyn.css

## Verification

- `git diff --check`
- `pnpm docs:build`