### PR TITLE
feat: add install script Pages Function

### DIFF
--- a/functions/install.sh.js
+++ b/functions/install.sh.js
@@ -1,0 +1,39 @@
+const INSTALL_SCRIPT_URL =
+  "https://raw.githubusercontent.com/gorse-io/gorse/master/cmd/gorse-cli/install.sh";
+
+const SCRIPT_HEADERS = {
+  "Content-Type": "text/x-shellscript; charset=utf-8",
+  "Cache-Control": "public, max-age=300, s-maxage=3600",
+  "X-Content-Type-Options": "nosniff",
+};
+
+export async function onRequestGet() {
+  const response = await fetch(INSTALL_SCRIPT_URL, {
+    cf: {
+      cacheEverything: true,
+      cacheTtl: 3600,
+    },
+  });
+
+  if (!response.ok) {
+    return new Response("failed to load install script\n", {
+      status: 502,
+      headers: {
+        "Content-Type": "text/plain; charset=utf-8",
+        "Cache-Control": "no-store",
+      },
+    });
+  }
+
+  return new Response(response.body, {
+    status: 200,
+    headers: SCRIPT_HEADERS,
+  });
+}
+
+export async function onRequestHead() {
+  return new Response(null, {
+    status: 200,
+    headers: SCRIPT_HEADERS,
+  });
+}


### PR DESCRIPTION
## Summary
- Add a Cloudflare Pages Function for /install.sh
- Proxy the gorse-cli install script from gorse-io/gorse
- Serve the script with shell-script content type and cache headers

## Test Plan
- node --check functions/install.sh.js
- Node smoke test for onRequestGet()/onRequestHead()
- pnpm docs:build