### PR TITLE
docs: add gorse-cli documentation

### DIFF
--- a/src/.vuepress/sidebar/en.ts
+++ b/src/.vuepress/sidebar/en.ts
@@ -77,6 +77,11 @@ export const enSidebar = sidebar({
       ]
     },
     {
+      "text": "CLI",
+      "icon": "terminal",
+      "link": "gorse-cli"
+    },
+    {
       "text": "Contribution Guide",
       "icon": "pullrequest",
       "link": "contribution-guide"

--- a/src/.vuepress/sidebar/zh.ts
+++ b/src/.vuepress/sidebar/zh.ts
@@ -77,6 +77,11 @@ export const zhSidebar = sidebar({
       ]
     },
     {
+      "text": "命令行工具",
+      "icon": "terminal",
+      "link": "gorse-cli"
+    },
+    {
       "text": "贡献指南",
       "icon": "pullrequest",
       "link": "contribution-guide"

--- a/src/.vuepress/theme.ts
+++ b/src/.vuepress/theme.ts
@@ -153,7 +153,7 @@ export default hopeTheme({
     },
 
     icon: {
-      assets: "https://at.alicdn.com/t/c/font_3748819_38n6x0qbyn.css",
+      assets: "https://at.alicdn.com/t/c/font_3748819_w15otx0kbjg.css",
     },
 
     // Install @vuepress/plugin-pwa and uncomment these if you want a PWA

--- a/src/docs/gorse-cli.md
+++ b/src/docs/gorse-cli.md
@@ -8,22 +8,9 @@ icon: terminal
 
 ## Installation
 
-### Homebrew
+::: code-tabs#install
 
-On macOS or Linux, install `gorse-cli` from the official [Gorse Homebrew tap](https://github.com/gorse-io/homebrew-tap):
-
-```bash
-brew tap gorse-io/tap
-brew install gorse-cli
-```
-
-You can also install it without tapping first:
-
-```bash
-brew install gorse-io/tap/gorse-cli
-```
-
-### Install script
+@tab:active Linux
 
 Install the latest `gorse-cli` release with the install script:
 
@@ -40,6 +27,41 @@ curl -fsSL https://gorse.io/install.sh | INSTALL_DIR="$HOME/.local/bin" sh
 # Install a specific version
 curl -fsSL https://gorse.io/install.sh | GORSE_CLI_VERSION=v0.5.8 sh
 ```
+
+If you use Homebrew on Linux, you can also install `gorse-cli` from the official [Gorse Homebrew tap](https://github.com/gorse-io/homebrew-tap):
+
+```bash
+brew install gorse-io/tap/gorse-cli
+```
+
+@tab macOS
+
+Install `gorse-cli` from the official [Gorse Homebrew tap](https://github.com/gorse-io/homebrew-tap):
+
+```bash
+brew tap gorse-io/tap
+brew install gorse-cli
+```
+
+You can also install it without tapping first:
+
+```bash
+brew install gorse-io/tap/gorse-cli
+```
+
+Alternatively, install with the install script:
+
+```bash
+curl -fsSL https://gorse.io/install.sh | sh
+```
+
+To install a specific release:
+
+```bash
+curl -fsSL https://gorse.io/install.sh | GORSE_CLI_VERSION=v0.5.8 sh
+```
+
+:::
 
 The install script supports Linux on `amd64`, `arm64`, and `riscv64`, and macOS on `arm64`. The installed binary is named `gorse-cli`.
 

--- a/src/docs/gorse-cli.md
+++ b/src/docs/gorse-cli.md
@@ -8,6 +8,23 @@ icon: terminal
 
 ## Installation
 
+### Homebrew
+
+On macOS or Linux, install `gorse-cli` from the official [Gorse Homebrew tap](https://github.com/gorse-io/homebrew-tap):
+
+```bash
+brew tap gorse-io/tap
+brew install gorse-cli
+```
+
+You can also install it without tapping first:
+
+```bash
+brew install gorse-io/tap/gorse-cli
+```
+
+### Install script
+
 Install the latest `gorse-cli` release with the install script:
 
 ```bash

--- a/src/docs/gorse-cli.md
+++ b/src/docs/gorse-cli.md
@@ -4,7 +4,7 @@ icon: terminal
 
 # Gorse CLI
 
-`gorse-cli` is a command line tool for managing a Gorse cluster. It provides terminal access to common dashboard and administration workflows, including cluster status, task progress, data inspection, recommendation preview, recommendation pipeline configuration, and backup or restore operations.
+`gorse-cli` is a command line tool for managing Gorse clusters. It provides terminal access to common dashboard and administration operations, including cluster status, task progress, data inspection, recommendation preview, recommendation pipeline configuration, and backup or restore operations.
 
 ## Installation
 
@@ -12,58 +12,27 @@ icon: terminal
 
 @tab:active Linux
 
-Install the latest `gorse-cli` release with the install script:
-
 ```bash
 curl -fsSL https://gorse.io/install.sh | sh
 ```
 
-By default, the script installs `gorse-cli` to `/usr/local/bin`. You can override the install directory or install a specific release:
-
-```bash
-# Install to a custom directory
-curl -fsSL https://gorse.io/install.sh | INSTALL_DIR="$HOME/.local/bin" sh
-
-# Install a specific version
-curl -fsSL https://gorse.io/install.sh | GORSE_CLI_VERSION=v0.5.8 sh
-```
-
-If you use Homebrew on Linux, you can also install `gorse-cli` from the official [Gorse Homebrew tap](https://github.com/gorse-io/homebrew-tap):
-
-```bash
-brew install gorse-io/tap/gorse-cli
-```
-
 @tab macOS
-
-Install `gorse-cli` from the official [Gorse Homebrew tap](https://github.com/gorse-io/homebrew-tap):
 
 ```bash
 brew tap gorse-io/tap
 brew install gorse-cli
 ```
 
-You can also install it without tapping first:
+@tab Windows
 
-```bash
-brew install gorse-io/tap/gorse-cli
-```
-
-Alternatively, install with the install script:
-
-```bash
-curl -fsSL https://gorse.io/install.sh | sh
-```
-
-To install a specific release:
-
-```bash
-curl -fsSL https://gorse.io/install.sh | GORSE_CLI_VERSION=v0.5.8 sh
+```powershell
+scoop bucket add gorse https://github.com/gorse-io/scoop-bucket
+scoop install gorse-cli
 ```
 
 :::
 
-The install script supports Linux on `amd64`, `arm64`, and `riscv64`, and macOS on `arm64`. The installed binary is named `gorse-cli`.
+The install script supports Linux on AMD64, ARM64, and RISCV64, and macOS on ARM64. Windows installation uses [Scoop](https://scoop.sh/). The installed binary is named `gorse-cli`.
 
 ## Authentication
 

--- a/src/docs/gorse-cli.md
+++ b/src/docs/gorse-cli.md
@@ -1,0 +1,229 @@
+---
+icon: terminal
+---
+
+# Gorse CLI
+
+`gorse-cli` is a command line tool for managing a Gorse cluster. It provides terminal access to common dashboard and administration workflows, including cluster status, task progress, data inspection, recommendation preview, recommendation pipeline configuration, and backup or restore operations.
+
+## Installation
+
+Install the latest `gorse-cli` release with the install script:
+
+```bash
+curl -fsSL https://gorse.io/install.sh | sh
+```
+
+By default, the script installs `gorse-cli` to `/usr/local/bin`. You can override the install directory or install a specific release:
+
+```bash
+# Install to a custom directory
+curl -fsSL https://gorse.io/install.sh | INSTALL_DIR="$HOME/.local/bin" sh
+
+# Install a specific version
+curl -fsSL https://gorse.io/install.sh | GORSE_CLI_VERSION=v0.5.8 sh
+```
+
+The install script supports Linux on `amd64`, `arm64`, and `riscv64`, and macOS on `arm64`. The installed binary is named `gorse-cli`.
+
+## Authentication
+
+Most commands need the Gorse master HTTP endpoint and the admin API key. You can provide them in three ways.
+
+### Save a context
+
+A context stores the endpoint and API key in the system keyring and selects it as the current context:
+
+```bash
+gorse-cli context add local --endpoint http://localhost:8088
+```
+
+The command prompts for the API key if `--api-key` is not provided. Use the current context for subsequent commands:
+
+```bash
+gorse-cli context current
+gorse-cli stats
+```
+
+Manage contexts with:
+
+```bash
+gorse-cli context list
+gorse-cli context use local
+gorse-cli context delete local
+```
+
+### Use environment variables
+
+```bash
+export GORSE_ADMIN_ENDPOINT=http://localhost:8088
+export GORSE_ADMIN_API_KEY=<api-key>
+
+gorse-cli stats
+```
+
+### Pass credentials per command
+
+```bash
+gorse-cli stats \
+  --endpoint http://localhost:8088 \
+  --api-key <api-key>
+```
+
+## Cluster and task status
+
+Use these commands to inspect the running cluster:
+
+```bash
+# List cluster nodes
+gorse-cli cluster-info
+
+# Show global statistics
+gorse-cli stats
+
+# List task progress
+gorse-cli ps
+```
+
+## Data inspection
+
+The `get` commands read users, items, feedback, and categories.
+
+```bash
+# List users or items
+gorse-cli get users -n 20
+gorse-cli get items -n 20
+
+# Get one user or item
+gorse-cli get user <user-id>
+gorse-cli get item <item-id>
+
+# List item categories
+gorse-cli get categories
+```
+
+Feedback can be filtered by type, user, and item:
+
+```bash
+# Latest feedback records
+gorse-cli get feedback -n 20
+
+# Feedback from a user
+gorse-cli get feedback --user <user-id>
+
+# Feedback on an item
+gorse-cli get feedback --item <item-id>
+
+# Typed feedback for a user-item pair
+gorse-cli get feedback --type like --user <user-id> --item <item-id>
+```
+
+## Recommendation preview
+
+The `recommend` commands preview dashboard recommendation results from the terminal.
+
+```bash
+# Latest items, optionally filtered by category
+gorse-cli recommend latest -n 10 --category news
+
+# Non-personalized recommendations by configured recommender name
+gorse-cli recommend non-personalized popular -n 10
+
+# Recommendations for a user
+gorse-cli recommend item-to-user <user-id> -n 10
+
+# Recommendations for a user from a specific recommender and name
+gorse-cli recommend item-to-user <user-id> collaborative similar -n 10
+
+# Item-to-item and user-to-user neighbors
+gorse-cli recommend item-to-item similar <item-id> -n 10
+gorse-cli recommend user-to-user similar <user-id> -n 10
+```
+
+Repeat `--category` to filter by multiple categories:
+
+```bash
+gorse-cli recommend item-to-user <user-id> --category news --category sports
+```
+
+## Recommendation pipeline configuration
+
+Use `pipeline` commands to view or modify the recommendation pipeline configuration. These commands operate on the `recommend` section of the Gorse configuration.
+
+```bash
+# Print the current recommendation pipeline configuration as YAML
+gorse-cli pipeline get
+
+# Print the recommendation pipeline JSON schema as YAML
+gorse-cli pipeline schema
+```
+
+Patch the pipeline with a JSON Patch document:
+
+```bash
+# Replace one value
+gorse-cli pipeline patch '[{"op":"replace","path":"/cache_size","value":1000}]'
+
+# Replace multiple values
+gorse-cli pipeline patch '[{"op":"replace","path":"/cache_size","value":1000},{"op":"replace","path":"/data_source/item_ttl","value":72}]'
+```
+
+Reset the recommendation pipeline to the file defaults:
+
+```bash
+gorse-cli pipeline reset
+```
+
+::: warning
+`pipeline reset` overwrites the current pipeline settings. The command asks for confirmation before applying the reset.
+:::
+
+## Backup and restore
+
+Export all Gorse data to a binary backup file:
+
+```bash
+gorse-cli dump backup.bin
+```
+
+Restore data from a backup file:
+
+```bash
+gorse-cli restore backup.bin
+```
+
+::: warning
+`restore` overwrites existing users, items, feedback, and cache data. The command asks for confirmation before restoring.
+:::
+
+## Command reference
+
+| Command | Description |
+| --- | --- |
+| `gorse-cli context add <name>` | Add or update a saved context. |
+| `gorse-cli context list` | List saved contexts. |
+| `gorse-cli context use <name>` | Switch the current context. |
+| `gorse-cli context current` | Show the current context. |
+| `gorse-cli context delete <name>` | Delete a saved context. |
+| `gorse-cli cluster-info` | List cluster nodes. |
+| `gorse-cli stats` | Show global statistics. |
+| `gorse-cli ps` | List task progress. |
+| `gorse-cli get users` | List users. |
+| `gorse-cli get user <user-id>` | Show one user. |
+| `gorse-cli get items` | List items. |
+| `gorse-cli get item <item-id>` | Show one item. |
+| `gorse-cli get feedback` | List or filter feedback. |
+| `gorse-cli get categories` | List item categories. |
+| `gorse-cli recommend latest` | Get latest items. |
+| `gorse-cli recommend non-personalized <name>` | Get non-personalized recommendations. |
+| `gorse-cli recommend item-to-user <user-id> [recommender] [name]` | Get recommendations for a user. |
+| `gorse-cli recommend item-to-item <name> <item-id>` | Get item-to-item recommendations. |
+| `gorse-cli recommend user-to-user <name> <user-id>` | Get user-to-user recommendations. |
+| `gorse-cli pipeline get` | Get recommendation pipeline configuration. |
+| `gorse-cli pipeline schema` | Get recommendation pipeline schema. |
+| `gorse-cli pipeline patch <json-patch>` | Patch recommendation pipeline values. |
+| `gorse-cli pipeline reset` | Reset recommendation pipeline to file defaults. |
+| `gorse-cli dump <file>` | Dump all Gorse data as a binary backup. |
+| `gorse-cli restore <file>` | Restore Gorse data from a binary backup. |
+
+Run `gorse-cli <command> --help` for command-specific flags and examples.

--- a/src/zh/docs/gorse-cli.md
+++ b/src/zh/docs/gorse-cli.md
@@ -4,7 +4,7 @@ icon: terminal
 
 # Gorse CLI
 
-`gorse-cli` 是用于管理 Gorse 集群的命令行工具。它把常见的控制台和运维操作带到终端中，包括查看集群状态、任务进度、用户和物品数据、推荐结果、推荐流程配置，以及数据备份和恢复。
+`gorse-cli` 是用于管理 Gorse 集群的命令行工具。它把常见的控制台和运维操作集成到终端中，包括查看集群状态、任务进度、用户和物品数据、推荐结果、推荐流程配置，以及数据备份和恢复。
 
 ## 安装
 
@@ -12,72 +12,41 @@ icon: terminal
 
 @tab:active Linux
 
-使用安装脚本安装最新版本的 `gorse-cli`：
-
 ```bash
 curl -fsSL https://gorse.io/install.sh | sh
 ```
 
-默认情况下，脚本会把 `gorse-cli` 安装到 `/usr/local/bin`。你也可以指定安装目录或安装特定版本：
-
-```bash
-# 安装到自定义目录
-curl -fsSL https://gorse.io/install.sh | INSTALL_DIR="$HOME/.local/bin" sh
-
-# 安装指定版本
-curl -fsSL https://gorse.io/install.sh | GORSE_CLI_VERSION=v0.5.8 sh
-```
-
-如果你在 Linux 上使用 Homebrew，也可以通过官方 [Gorse Homebrew tap](https://github.com/gorse-io/homebrew-tap) 安装 `gorse-cli`：
-
-```bash
-brew install gorse-io/tap/gorse-cli
-```
-
 @tab macOS
-
-通过官方 [Gorse Homebrew tap](https://github.com/gorse-io/homebrew-tap) 安装 `gorse-cli`：
 
 ```bash
 brew tap gorse-io/tap
 brew install gorse-cli
 ```
 
-也可以不提前 tap，直接安装：
+@tab Windows
 
-```bash
-brew install gorse-io/tap/gorse-cli
-```
-
-或者使用安装脚本安装：
-
-```bash
-curl -fsSL https://gorse.io/install.sh | sh
-```
-
-安装指定版本：
-
-```bash
-curl -fsSL https://gorse.io/install.sh | GORSE_CLI_VERSION=v0.5.8 sh
+```powershell
+scoop bucket add gorse https://github.com/gorse-io/scoop-bucket
+scoop install gorse-cli
 ```
 
 :::
 
-安装脚本支持 Linux 的 `amd64`、`arm64`、`riscv64`，以及 macOS 的 `arm64`。安装后的二进制名称为 `gorse-cli`。
+安装脚本支持 AMD64、ARM64、RISCV64 架构的Linux，以及 ARM64 架构的 macOS。Windows 安装使用 [Scoop](https://scoop.sh/)。安装后的二进制名称为 `gorse-cli`。
 
 ## 认证
 
-大多数命令都需要 Gorse master 的 HTTP 地址和管理员 API Key。你可以通过以下三种方式提供认证信息。
+大多数命令都需要 Gorse master 节点的 HTTP 地址和管理员 API 密钥。你可以通过以下三种方式提供认证信息。
 
 ### 保存上下文
 
-上下文会把 endpoint 和 API Key 保存到系统 keyring，并将该上下文设为当前上下文：
+上下文会把 master 节点地址和 API 密钥保存到本地，并将该上下文设为当前上下文：
 
 ```bash
 gorse-cli context add local --endpoint http://localhost:8088
 ```
 
-如果没有传入 `--api-key`，命令会提示输入 API Key。后续命令会自动使用当前上下文：
+如果没有传入 `--api-key`，命令会提示输入 API 密钥。后续命令会自动使用当前上下文：
 
 ```bash
 gorse-cli context current
@@ -116,7 +85,7 @@ gorse-cli stats \
 # 列出集群节点
 gorse-cli cluster-info
 
-# 查看全局统计信息
+# 查看统计信息
 gorse-cli stats
 
 # 查看任务进度
@@ -125,7 +94,7 @@ gorse-cli ps
 
 ## 数据查看
 
-`get` 命令用于读取用户、物品、反馈和分类。
+`get` 命令用于读取用户、物品、反馈和类别。
 
 ```bash
 # 列出用户或物品
@@ -136,7 +105,7 @@ gorse-cli get items -n 20
 gorse-cli get user <user-id>
 gorse-cli get item <item-id>
 
-# 列出物品分类
+# 列出物品类别
 gorse-cli get categories
 ```
 
@@ -158,7 +127,7 @@ gorse-cli get feedback --type like --user <user-id> --item <item-id>
 
 ## 推荐结果预览
 
-`recommend` 命令可以在终端中预览控制台推荐接口的结果。
+`recommend` 命令可以在终端中预览推荐接口的结果。
 
 ```bash
 # 最新物品，可按分类过滤
@@ -173,12 +142,12 @@ gorse-cli recommend item-to-user <user-id> -n 10
 # 使用指定推荐器和名称给用户推荐物品
 gorse-cli recommend item-to-user <user-id> collaborative similar -n 10
 
-# 物品到物品和用户到用户邻居
+# 相似物品和相似用户
 gorse-cli recommend item-to-item similar <item-id> -n 10
 gorse-cli recommend user-to-user similar <user-id> -n 10
 ```
 
-可以重复传入 `--category` 以按多个分类过滤：
+可以重复传入 `--category` 以按多个类别过滤：
 
 ```bash
 gorse-cli recommend item-to-user <user-id> --category news --category sports
@@ -244,19 +213,19 @@ gorse-cli restore backup.bin
 | `gorse-cli context current` | 显示当前上下文。 |
 | `gorse-cli context delete <name>` | 删除保存的上下文。 |
 | `gorse-cli cluster-info` | 列出集群节点。 |
-| `gorse-cli stats` | 显示全局统计信息。 |
+| `gorse-cli stats` | 显示统计信息。 |
 | `gorse-cli ps` | 列出任务进度。 |
 | `gorse-cli get users` | 列出用户。 |
 | `gorse-cli get user <user-id>` | 显示单个用户。 |
 | `gorse-cli get items` | 列出物品。 |
 | `gorse-cli get item <item-id>` | 显示单个物品。 |
 | `gorse-cli get feedback` | 列出或过滤反馈。 |
-| `gorse-cli get categories` | 列出物品分类。 |
+| `gorse-cli get categories` | 列出物品类别。 |
 | `gorse-cli recommend latest` | 获取最新物品。 |
 | `gorse-cli recommend non-personalized <name>` | 获取非个性化推荐。 |
 | `gorse-cli recommend item-to-user <user-id> [recommender] [name]` | 给用户推荐物品。 |
-| `gorse-cli recommend item-to-item <name> <item-id>` | 获取物品到物品推荐。 |
-| `gorse-cli recommend user-to-user <name> <user-id>` | 获取用户到用户推荐。 |
+| `gorse-cli recommend item-to-item <name> <item-id>` | 获取相似物品。 |
+| `gorse-cli recommend user-to-user <name> <user-id>` | 获取相似用户。 |
 | `gorse-cli pipeline get` | 获取推荐流程配置。 |
 | `gorse-cli pipeline schema` | 获取推荐流程 Schema。 |
 | `gorse-cli pipeline patch <json-patch>` | 修改推荐流程配置值。 |

--- a/src/zh/docs/gorse-cli.md
+++ b/src/zh/docs/gorse-cli.md
@@ -8,22 +8,9 @@ icon: terminal
 
 ## 安装
 
-### Homebrew
+::: code-tabs#install
 
-在 macOS 或 Linux 上，可以通过官方 [Gorse Homebrew tap](https://github.com/gorse-io/homebrew-tap) 安装 `gorse-cli`：
-
-```bash
-brew tap gorse-io/tap
-brew install gorse-cli
-```
-
-也可以不提前 tap，直接安装：
-
-```bash
-brew install gorse-io/tap/gorse-cli
-```
-
-### 安装脚本
+@tab:active Linux
 
 使用安装脚本安装最新版本的 `gorse-cli`：
 
@@ -40,6 +27,41 @@ curl -fsSL https://gorse.io/install.sh | INSTALL_DIR="$HOME/.local/bin" sh
 # 安装指定版本
 curl -fsSL https://gorse.io/install.sh | GORSE_CLI_VERSION=v0.5.8 sh
 ```
+
+如果你在 Linux 上使用 Homebrew，也可以通过官方 [Gorse Homebrew tap](https://github.com/gorse-io/homebrew-tap) 安装 `gorse-cli`：
+
+```bash
+brew install gorse-io/tap/gorse-cli
+```
+
+@tab macOS
+
+通过官方 [Gorse Homebrew tap](https://github.com/gorse-io/homebrew-tap) 安装 `gorse-cli`：
+
+```bash
+brew tap gorse-io/tap
+brew install gorse-cli
+```
+
+也可以不提前 tap，直接安装：
+
+```bash
+brew install gorse-io/tap/gorse-cli
+```
+
+或者使用安装脚本安装：
+
+```bash
+curl -fsSL https://gorse.io/install.sh | sh
+```
+
+安装指定版本：
+
+```bash
+curl -fsSL https://gorse.io/install.sh | GORSE_CLI_VERSION=v0.5.8 sh
+```
+
+:::
 
 安装脚本支持 Linux 的 `amd64`、`arm64`、`riscv64`，以及 macOS 的 `arm64`。安装后的二进制名称为 `gorse-cli`。
 

--- a/src/zh/docs/gorse-cli.md
+++ b/src/zh/docs/gorse-cli.md
@@ -1,0 +1,228 @@
+---
+icon: terminal
+---
+
+# Gorse CLI
+
+`gorse-cli` 是用于管理 Gorse 集群的命令行工具。它把常见的控制台和运维操作带到终端中，包括查看集群状态、任务进度、用户和物品数据、推荐结果、推荐流程配置，以及数据备份和恢复。
+
+## 安装
+
+使用安装脚本安装最新版本的 `gorse-cli`：
+
+```bash
+curl -fsSL https://gorse.io/install.sh | sh
+```
+
+默认情况下，脚本会把 `gorse-cli` 安装到 `/usr/local/bin`。你也可以指定安装目录或安装特定版本：
+
+```bash
+# 安装到自定义目录
+curl -fsSL https://gorse.io/install.sh | INSTALL_DIR="$HOME/.local/bin" sh
+
+# 安装指定版本
+curl -fsSL https://gorse.io/install.sh | GORSE_CLI_VERSION=v0.5.8 sh
+```
+
+安装脚本支持 Linux 的 `amd64`、`arm64`、`riscv64`，以及 macOS 的 `arm64`。安装后的二进制名称为 `gorse-cli`。
+
+## 认证
+
+大多数命令都需要 Gorse master 的 HTTP 地址和管理员 API Key。你可以通过以下三种方式提供认证信息。
+
+### 保存上下文
+
+上下文会把 endpoint 和 API Key 保存到系统 keyring，并将该上下文设为当前上下文：
+
+```bash
+gorse-cli context add local --endpoint http://localhost:8088
+```
+
+如果没有传入 `--api-key`，命令会提示输入 API Key。后续命令会自动使用当前上下文：
+
+```bash
+gorse-cli context current
+gorse-cli stats
+```
+
+管理上下文：
+
+```bash
+gorse-cli context list
+gorse-cli context use local
+gorse-cli context delete local
+```
+
+### 使用环境变量
+
+```bash
+export GORSE_ADMIN_ENDPOINT=http://localhost:8088
+export GORSE_ADMIN_API_KEY=<api-key>
+gorse-cli stats
+```
+
+### 在单次命令中传入认证信息
+
+```bash
+gorse-cli stats \
+  --endpoint http://localhost:8088 \
+  --api-key <api-key>
+```
+
+## 集群和任务状态
+
+使用以下命令查看正在运行的集群：
+
+```bash
+# 列出集群节点
+gorse-cli cluster-info
+
+# 查看全局统计信息
+gorse-cli stats
+
+# 查看任务进度
+gorse-cli ps
+```
+
+## 数据查看
+
+`get` 命令用于读取用户、物品、反馈和分类。
+
+```bash
+# 列出用户或物品
+gorse-cli get users -n 20
+gorse-cli get items -n 20
+
+# 查看单个用户或物品
+gorse-cli get user <user-id>
+gorse-cli get item <item-id>
+
+# 列出物品分类
+gorse-cli get categories
+```
+
+反馈可以按类型、用户和物品过滤：
+
+```bash
+# 最新反馈记录
+gorse-cli get feedback -n 20
+
+# 某个用户的反馈
+gorse-cli get feedback --user <user-id>
+
+# 某个物品的反馈
+gorse-cli get feedback --item <item-id>
+
+# 某个用户-物品对的指定类型反馈
+gorse-cli get feedback --type like --user <user-id> --item <item-id>
+```
+
+## 推荐结果预览
+
+`recommend` 命令可以在终端中预览控制台推荐接口的结果。
+
+```bash
+# 最新物品，可按分类过滤
+gorse-cli recommend latest -n 10 --category news
+
+# 指定名称的非个性化推荐
+gorse-cli recommend non-personalized popular -n 10
+
+# 给用户推荐物品
+gorse-cli recommend item-to-user <user-id> -n 10
+
+# 使用指定推荐器和名称给用户推荐物品
+gorse-cli recommend item-to-user <user-id> collaborative similar -n 10
+
+# 物品到物品和用户到用户邻居
+gorse-cli recommend item-to-item similar <item-id> -n 10
+gorse-cli recommend user-to-user similar <user-id> -n 10
+```
+
+可以重复传入 `--category` 以按多个分类过滤：
+
+```bash
+gorse-cli recommend item-to-user <user-id> --category news --category sports
+```
+
+## 推荐流程配置
+
+使用 `pipeline` 命令查看或修改推荐流程配置。这些命令操作的是 Gorse 配置中的 `recommend` 部分。
+
+```bash
+# 以 YAML 输出当前推荐流程配置
+gorse-cli pipeline get
+
+# 以 YAML 输出推荐流程 JSON Schema
+gorse-cli pipeline schema
+```
+
+使用 JSON Patch 修改推荐流程：
+
+```bash
+# 替换单个配置值
+gorse-cli pipeline patch '[{"op":"replace","path":"/cache_size","value":1000}]'
+
+# 替换多个配置值
+gorse-cli pipeline patch '[{"op":"replace","path":"/cache_size","value":1000},{"op":"replace","path":"/data_source/item_ttl","value":72}]'
+```
+
+把推荐流程重置为配置文件中的默认值：
+
+```bash
+gorse-cli pipeline reset
+```
+
+::: warning
+`pipeline reset` 会覆盖当前推荐流程设置。命令会在执行前请求确认。
+:::
+
+## 备份和恢复
+
+把所有 Gorse 数据导出为二进制备份文件：
+
+```bash
+gorse-cli dump backup.bin
+```
+
+从备份文件恢复数据：
+
+```bash
+gorse-cli restore backup.bin
+```
+
+::: warning
+`restore` 会覆盖现有用户、物品、反馈和缓存数据。命令会在恢复前请求确认。
+:::
+
+## 命令参考
+
+| 命令 | 说明 |
+| --- | --- |
+| `gorse-cli context add <name>` | 添加或更新保存的上下文。 |
+| `gorse-cli context list` | 列出保存的上下文。 |
+| `gorse-cli context use <name>` | 切换当前上下文。 |
+| `gorse-cli context current` | 显示当前上下文。 |
+| `gorse-cli context delete <name>` | 删除保存的上下文。 |
+| `gorse-cli cluster-info` | 列出集群节点。 |
+| `gorse-cli stats` | 显示全局统计信息。 |
+| `gorse-cli ps` | 列出任务进度。 |
+| `gorse-cli get users` | 列出用户。 |
+| `gorse-cli get user <user-id>` | 显示单个用户。 |
+| `gorse-cli get items` | 列出物品。 |
+| `gorse-cli get item <item-id>` | 显示单个物品。 |
+| `gorse-cli get feedback` | 列出或过滤反馈。 |
+| `gorse-cli get categories` | 列出物品分类。 |
+| `gorse-cli recommend latest` | 获取最新物品。 |
+| `gorse-cli recommend non-personalized <name>` | 获取非个性化推荐。 |
+| `gorse-cli recommend item-to-user <user-id> [recommender] [name]` | 给用户推荐物品。 |
+| `gorse-cli recommend item-to-item <name> <item-id>` | 获取物品到物品推荐。 |
+| `gorse-cli recommend user-to-user <name> <user-id>` | 获取用户到用户推荐。 |
+| `gorse-cli pipeline get` | 获取推荐流程配置。 |
+| `gorse-cli pipeline schema` | 获取推荐流程 Schema。 |
+| `gorse-cli pipeline patch <json-patch>` | 修改推荐流程配置值。 |
+| `gorse-cli pipeline reset` | 重置推荐流程为文件默认值。 |
+| `gorse-cli dump <file>` | 把所有 Gorse 数据导出为二进制备份。 |
+| `gorse-cli restore <file>` | 从二进制备份恢复 Gorse 数据。 |
+
+运行 `gorse-cli <command> --help` 查看具体命令的参数和示例。

--- a/src/zh/docs/gorse-cli.md
+++ b/src/zh/docs/gorse-cli.md
@@ -8,6 +8,23 @@ icon: terminal
 
 ## 安装
 
+### Homebrew
+
+在 macOS 或 Linux 上，可以通过官方 [Gorse Homebrew tap](https://github.com/gorse-io/homebrew-tap) 安装 `gorse-cli`：
+
+```bash
+brew tap gorse-io/tap
+brew install gorse-cli
+```
+
+也可以不提前 tap，直接安装：
+
+```bash
+brew install gorse-io/tap/gorse-cli
+```
+
+### 安装脚本
+
 使用安装脚本安装最新版本的 `gorse-cli`：
 
 ```bash


### PR DESCRIPTION
## Summary
- Add English and Chinese documentation for the new `gorse-cli` command line tool
- Document installation, authentication, cluster/task inspection, data inspection, recommendation preview, pipeline configuration, backup, and restore workflows
- Add CLI documentation to the docs sidebar at the same level as Dashboard

## Test Plan
- `git diff --check`
- `pnpm docs:build`