### PR TITLE
docs: add CLI links to docs index

### DIFF
--- a/src/docs/README.md
+++ b/src/docs/README.md
@@ -36,6 +36,7 @@ Welcome to the official documents for the Gorse recommender system.
   - [Ruby SDK](api/ruby-sdk.md)
   - [.NET SDK](api/dotnet-sdk.md)
 - [Dashboard](dashboard/overview.md)
+- [CLI](gorse-cli.md)
 - [Contribution Guide](contribution-guide.md)
 - [FAQ](faq.md)
 

--- a/src/zh/docs/README.md
+++ b/src/zh/docs/README.md
@@ -36,6 +36,7 @@ icon: explore
     - [Ruby SDK](api/ruby-sdk.md)
     - [.NET SDK](api/dotnet-sdk.md)
 - [控制台](dashboard/overview.md)
+- [命令行工具](gorse-cli.md)
 - [贡献指南](contribution-guide.md)
 - [常见问题](faq.md)
 


### PR DESCRIPTION
## Summary
- Add the CLI documentation link to the English docs index page
- Add the command-line tool link to the Chinese docs index page

## Test Plan
- git diff --check
- pnpm docs:build